### PR TITLE
Remove unused find_packages import and un-useful include_package_data setup kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 version = '0.2.1'
 
@@ -26,7 +26,6 @@ setup(name='datazilla',
       url='https://github.com/mozilla/datazilla_client',
       license='MPL',
       packages=['datazilla'],
-      include_package_data=True,
       zip_safe=False,
       install_requires=deps,
       )


### PR DESCRIPTION
This pull request removes an unused import from setup.py, and also removes `include_package_data=True` from the `setup()` call. `include_package_data=True` includes all VCS-tracked files as package-data files, but only Subversion is supported natively, so for a git-hosted project an extra setuptools plugin would be required for that to have any effect. But datazilla-client has no package data files anyway, so it's kind of moot.
