### PR TITLE
Correct docstring location/format, fix mutable-default-argument bugs.

### DIFF
--- a/datazilla/datazilla.py
+++ b/datazilla/datazilla.py
@@ -8,34 +8,31 @@ import urllib2
 import json
 import time
 
-"""
-This is a helper class for managing testsuites and their test results
-Currently, the results are a dictionary of {"testsuite":{"testname":[values], ...}} 
-"""
 class DatazillaResult(object):
-    def __init__(self, results={}):
-      self.results = results
-    
     """
-    Add a testsuite of {"testname":[values],...} to the results
+    A helper class for managing testsuites and their test results.
+
+    Currently, the results are a dictionary of
+    {"testsuite":{"testname":[values], ...}}
+
     """
-    def add_testsuite(self, suite_name, results={}):
-        self.results[suite_name] = results
-        
-    """
-    Adds a list of result values to the results in the given testsuite/testname pair 
-    """
+    def __init__(self, results=None):
+        self.results = results or {}
+
+    def add_testsuite(self, suite_name, results=None):
+        """Add a testsuite of {"testname":[values],...} to the results."""
+        self.results[suite_name] = results or {}
+
     def add_test_results(self, suite_name, test_name, values):
+        """Add a list of result values to the given testsuite/testname pair."""
         if self.results.has_key(suite_name):
             if self.results[suite_name].has_key(test_name):
                 self.results[suite_name][test_name].extend(values)
             else:
                 self.results[suite_name][test_name] = values
 
-    """
-    Add a dictionary of {"testsuite":{"testname":[values], ...}} to the results
-    """
     def join_results(self, results):
+        """Add a dictionary of {"suite":{"name":[values], ...}} to results."""
         for suite in results:
              if self.results.has_key(suite):
                 for test in results[suite]:
@@ -43,14 +40,17 @@ class DatazillaResult(object):
              else:
                 self.results[suite] = results[suite]
 
-"""
-Datazilla request object that manages test information and submission.
-Note that the revision id can be 16 characters, maximum.
-"""
+
 class DatazillaRequest(object):
+    """
+    Datazilla request object that manages test information and submission.
+
+    Note that the revision id can be 16 characters, maximum.
+
+    """
     def __init__(self, server, machine_name="", os="", os_version="", platform="",
                  build_name="", version="", revision="", branch="", id="",
-                 test_date=int(time.time())):
+                 test_date=None):
         self.server = server
         self.machine_name = machine_name
         self.os = os
@@ -61,19 +61,17 @@ class DatazillaRequest(object):
         self.revision = revision
         self.branch = branch
         self.id = id
+        if test_date is None:
+            test_date = int(time.time())
         self.test_date = test_date
-        self.results = DatazillaResult()   
-        
-    """
-    Join a DatazillaResult object to the results
-    """
+        self.results = DatazillaResult()
+
     def add_datazilla_result(self, res):
+        """Join a DatazillaResult object to the results."""
         self.results.join_results(res.results)
 
-    """
-    Submit test data to datazilla server
-    """
     def submit(self):
+        """Submit test data to datazilla server."""
         if self.server is None:
             raise "Data server is not set!"
 
@@ -99,8 +97,8 @@ class DatazillaRequest(object):
         }
 
         datasets = []
-        for suite, data in self.results.results.items(): 
-            perf_json['testrun']['suite'] = suite 
+        for suite, data in self.results.results.items():
+            perf_json['testrun']['suite'] = suite
             perf_json['results'] = data;
             datasets.append(deepcopy(perf_json))
             perf_json['results'] = {}


### PR DESCRIPTION
Moved the docstrings below the class/function definition, which is the more typical location (and allows them to be found and used by Python auto-documentation tools, the online shell help() function, etc.) Also formatted them in the standard way per PEP 257 (http://www.python.org/dev/peps/pep-0257/).

Also fixed a few cases where default arguments were used in a way that would cause a subtle bug. Default arguments are evaluated at function-definition time, not function-execution time, so for instance if the default value for `test_date` is `int(time.time())`, that will be evaluated exactly once when the module is first imported, not each time a `DatazillaRequest` is created. This could be a problem in a long-running process that repeatedly creates and sends `DatazillaRequest`s.

Similarly, but even more subtly, if `[]` or `{}` (or any mutable object) is used as a default argument for a function, that creates exactly one instance of a list or dictionary, whose state will persist over time (and be shared across multiple instances of the function or class). This can be useful in some rare cases, but is almost never the desired result. For instance, with the default value of the optional `results` argument to the `DatazillaResult` constructor set to `{}`, if I run the following code:

```
res1 = DatazillaResult()
res1.add_testsuite("talos", ["1", "2"])
res2 = DatazillaResult()
```

The value of both `res1.results` and `res2.results` will, surprisingly enough, _both_ be `{'talos': ['1', '2']}`. Even more surprisingly, both instances are actually sharing the same results dictionary, and any modification I make to one (i.e. adding more results) will instantly be reflected in the other as well! Because the empty-dictionary default argument is assigned to `self.results` in `res1.__init__`, but that assignment is just a reference, not a copy - there's still only one dictionary, and it's the same one that is also still the default value of the argument in the constructor. So when I add some data to `self.results` in `res1` with the second line, I'm actually adding it to the dictionary that is the default `results` argument for all `DatazillaResult'`s - and that will be also assigned to `self.results` for any future `DatazillaResult`s that are instantiated without an explicit `results` argument.

Anyway, sorry for the novel - but the solution is simple: avoid calling any functions or using any mutable objects as function default arguments. Instead use a sentinel no-argument-provided value (usually `None`) and replace it with the correct value inside the function.
