### PR TITLE
Tests and docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+datazilla.egg-info/
+htmlcov/
+*.egg

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Usage
         )
     req.add_datazilla_result(res)
     req.submit()
+
+
+Development
+-----------
+
+To run the `datazilla_client` test suite, run `python setup.py test`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,27 @@ datazilla_client
 ================
 
 Client libraries to interact with the datazilla database.
+
+Usage
+-----
+
+    from datazilla import DatazillaRequest, DatazillaResult
+    
+    res = DatazillaResult()
+    res.add_testsuite("suite_name", {"test_name": [1, 2, 3]})
+    res.add_test_results("suite_name", "another_test", [2, 3, 4])
+    
+    req = DatazillaRequest(
+        server="datazilla.mozilla.org/project/api/load_test",
+        machine_name="qm-pxp01",
+        os="linux",
+        os_version="Ubuntu 11.10",
+        platform="x86_64",
+        build_name="Firefox",
+        version="14.0a2",
+        revision="785345035a3b",
+        branch="Mozilla-Aurora",
+        id="20120228122102",
+        )
+    req.add_datazilla_result(res)
+    req.submit()

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Usage
     req.add_datazilla_result(res)
     req.submit()
 
+If you don't want to use `DatazillaResult` to build up the data structure to
+send, you can still use `DatazillaRequest` to send it:
+
+    req = DatazillaRequest("datazilla.mozilla.org/project/api/load_test")
+    data_to_send = ...
+    req.send(data_to_send)
+
 
 Development
 -----------

--- a/datazilla/datazilla.py
+++ b/datazilla/datazilla.py
@@ -25,7 +25,7 @@ class DatazillaResult(object):
 
     def add_test_results(self, suite_name, test_name, values):
         """Add a list of result values to the given testsuite/testname pair."""
-        suite = self.results.setdefault("suite", {})
+        suite = self.results.setdefault(suite_name, {})
         suite.setdefault(test_name, []).extend(values)
 
     def join_results(self, results):

--- a/datazilla/tests/test_datazilla_request.py
+++ b/datazilla/tests/test_datazilla_request.py
@@ -1,0 +1,125 @@
+from unittest import TestCase
+
+from mock import patch
+
+from ..datazilla import DatazillaRequest, DatazillaResult
+
+
+
+class DatazillaRequestTest(TestCase):
+    def test_init_with_date(self):
+        """Can provide test date on instantiation."""
+        req = DatazillaRequest('server', test_date=12345)
+
+        self.assertEqual(req.test_date, 12345)
+
+
+    def test_add_datazilla_result(self):
+        """Can add a DatazillaResult to a DatazillaRequest."""
+        req = DatazillaRequest('server')
+        res = DatazillaResult({'suite': {'test': [1, 2, 3]}})
+
+        req.add_datazilla_result(res)
+
+        self.assertEqual(req.results.results, res.results)
+
+
+    def test_add_second_datazilla_result(self):
+        """Adding a second DatazillaResult joins their results."""
+        req = DatazillaRequest('server')
+        res1 = DatazillaResult({'suite1': {'test': [1]}})
+        res2 = DatazillaResult({'suite2': {'test': [2]}})
+
+        req.add_datazilla_result(res1)
+        req.add_datazilla_result(res2)
+
+        self.assertEqual(
+            req.results.results,
+            {'suite1': {'test': [1]}, 'suite2': {'test': [2]}},
+            )
+
+
+    @patch.object(DatazillaRequest, 'send')
+    def test_submit(self, mock_send):
+        """Submits blob of JSON data for each test suite."""
+        req = DatazillaRequest(
+            server='datazilla.mozilla.org/project/api/load_test',
+            machine_name='qm-pxp01',
+            os='linux',
+            os_version='Ubuntu 11.10',
+            platform='x86_64',
+            build_name='Firefox',
+            version='14.0a2',
+            revision='785345035a3b',
+            branch='Mozilla-Aurora',
+            id='20120228122102',
+            )
+
+        req.add_datazilla_result(
+            DatazillaResult(
+                {'suite1': {'test1': [1]}, 'suite2': {'test2': [2]}}
+                )
+            )
+
+        req.submit()
+
+        self.assertEqual(mock_send.call_count, 2)
+        data1 = mock_send.call_args_list[0][0][0]
+        data2 = mock_send.call_args_list[1][0][0]
+
+        results = sorted([data1.pop('results'), data2.pop('results')])
+
+        self.assertEqual(results, sorted([{'test1': [1]}, {'test2': [2]}]))
+
+        suites = sorted(
+            [data1['testrun'].pop('suite'), data2['testrun'].pop('suite')])
+
+        self.assertEqual(suites, sorted(['suite1', 'suite2']))
+
+        # aside from results and suite, datasets are the same
+        self.assertEqual(data1, data2)
+
+        self.assertEqual(
+            data1['test_build'],
+            {
+                'branch': 'Mozilla-Aurora',
+                'id': '20120228122102',
+                'name': 'Firefox',
+                'revision': '785345035a3b',
+                'version': '14.0a2',
+                },
+            )
+
+        self.assertEqual(
+            data1['test_machine'],
+            {
+                'name': 'qm-pxp01',
+                'os': 'linux',
+                'osversion': 'Ubuntu 11.10',
+                'platform': 'x86_64',
+                },
+            )
+
+        self.assertEqual(data1['testrun']['date'], req.test_date)
+
+
+    @patch("datazilla.datazilla.urllib2.urlopen")
+    def test_send(self, mock_urlopen):
+        """Can send data to the server."""
+        server = "datazilla.mozilla.org/project/api/load_test"
+        req = DatazillaRequest(server)
+
+        req.send({"some": "data"})
+
+        self.assertEqual(mock_urlopen.call_count, 1)
+        request = mock_urlopen.call_args[0][0]
+
+        self.assertEqual(request.get_full_url(), server)
+
+        self.assertEqual(
+            request.get_data(), 'data=%7B%22some%22%3A+%22data%22%7D')
+
+        self.assertEqual(
+            request.headers['Content-type'],
+            'application/x-www-form-urlencoded',
+            )

--- a/datazilla/tests/test_datazilla_result.py
+++ b/datazilla/tests/test_datazilla_result.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+
+from ..datazilla import DatazillaResult
+
+
+
+class DatazillaResultTest(TestCase):
+    def test_init_with_results(self):
+        """Can initialize with a dictionary of results."""
+        data = {"suite": {"test": [1, 2, 3]}}
+        res = DatazillaResult(data)
+
+        self.assertEqual(res.results, data)
+
+
+    def test_init_noargs(self):
+        """Can initialize with no argument and get empty initial results."""
+        res = DatazillaResult()
+
+        self.assertEqual(res.results, {})
+
+
+    def test_add_testsuite(self):
+        """Can add a test suite with tests and results."""
+        res = DatazillaResult()
+        res.add_testsuite("suite", {"test1": [1, 2, 3]})
+
+        self.assertEqual(res.results, {"suite": {"test1": [1, 2, 3]}})
+
+
+    def test_add_test_results(self):
+        """Can add results to a suite."""
+        res = DatazillaResult()
+        res.add_test_results("suite", "test", [1, 2, 3])
+
+        self.assertEqual(res.results, {"suite": {"test": [1, 2, 3]}})
+
+
+    def test_join_results(self):
+        """Can merge a full results dictionary into this result."""
+        res = DatazillaResult({"suite1": {"test1a": [1]}})
+
+        res.join_results(
+            {
+                "suite1": {"test1a": [2], "test1b": [3]},
+                "suite2": {"test2a": [4]},
+                }
+            )
+
+        self.assertEqual(
+            res.results,
+            {
+                "suite1": {"test1a": [1, 2], "test1b": [3]},
+                "suite2": {"test2a": [4]},
+                }
+            )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import sys
 from setuptools import setup
 
 version = '0.2.1'
@@ -28,4 +27,6 @@ setup(name='datazilla',
       packages=['datazilla'],
       zip_safe=False,
       install_requires=deps,
+      test_suite='datazilla.tests',
+      tests_require=["mock"],
       )


### PR DESCRIPTION
This branch adds 100% test coverage, and basic usage docs.

There are a couple minor behavior changes as well:
- The request to the datazilla server is now sent with a content-type header.
- `DatazillaResult.add_test_results` is now able to accept results for a new suite, in which case it implicitly adds the suite.
- Fixed a bug in `DatazillaResult.join_results` where it crashed if the joined results had results for a new test in an already-existing suite.
- Extracted out the `DatazillaRequest.send` method, allowing projects that build up the data structure to send themselves to still use the client to send the data. (At the moment this doesn't buy them very much, but I'm about to add OAuth support, which will make it much more worthwhile).

All of these changes should be backwards-compatible for any existing code using `datazilla_client`.
