### PR TITLE
allow use of simplejson vs json

### DIFF
--- a/dzclient/client.py
+++ b/dzclient/client.py
@@ -4,13 +4,15 @@
 
 from copy import deepcopy
 import httplib
-import json
 import oauth2 as oauth
 import time
 import urllib
 from urlparse import urlparse
 
-
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 class DatazillaResult(object):
     """


### PR DESCRIPTION
the setup.py already adds simplejson as a dep if json isn't available (python < 2.6).  However, client.py does not actually make use of it.  This will allow it
