### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 datazilla.egg-info/
 htmlcov/
 *.egg
+.tox/

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Development
 -----------
 
 To run the `datazilla_client` test suite, run `python setup.py test`.
+
+If you have `python2.5`, `python2.6`, and `python2.7` available on your system
+under those names, you can also `pip install tox` and then run `tox` to test
+`datazilla_client` under all of those Python versions.

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py25,py26,py27
+
+[testenv]
+deps=
+  mock
+commands=python setup.py test


### PR DESCRIPTION
We should add a tox.ini to automatically test dzclient on multiple Python versions (and consider supporting 2.4 so Talos can use it).
