### PR TITLE
Https protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Usage
     res.add_test_results("suite_name", "another_test", [2, 3, 4])
 
     req = DatazillaRequest(
+        protocol="https",
         host="datazilla.mozilla.org",
         project="project",
         oauth_key="oauth-key",
@@ -37,6 +38,7 @@ If you don't want to use `DatazillaResult` to build up the data structure to
 send, you can still use `DatazillaRequest` to send it:
 
     req = DatazillaRequest(
+        protocol="https",
         host="datazilla.mozilla.org",
         project="project",
         oauth_key="oauth-key",

--- a/dzclient/client.py
+++ b/dzclient/client.py
@@ -141,7 +141,9 @@ class DatazillaRequest(DatazillaResultsCollection):
         self.oauth_key = oauth_key
         self.oauth_secret = oauth_secret
 
-        if protocol in set(['http', 'https']):
+        self.protocols = set(['http', 'https'])
+
+        if protocol in self.protocols:
             self.protocol = protocol
         else:
             #Default to https

--- a/dzclient/client.py
+++ b/dzclient/client.py
@@ -193,10 +193,10 @@ class DatazillaRequest(DatazillaResultsCollection):
         header = {'Content-type': 'application/x-www-form-urlencoded'}
 
         conn = None
-        if self.protocol == 'https':
-            conn = httplib.HTTPSConnection(self.host)
-        else:
+        if self.protocol == 'http':
             conn = httplib.HTTPConnection(self.host)
+        else:
+            conn = httplib.HTTPSConnection(self.host)
 
         conn.request("POST", path, req.to_postdata(), header)
         return conn.getresponse()

--- a/dzclient/tests/test_datazilla_request.py
+++ b/dzclient/tests/test_datazilla_request.py
@@ -7,14 +7,16 @@ class DatazillaRequestTest(unittest.TestCase):
     def test_init_with_date(self):
         """Can provide test date on instantiation."""
         req = DatazillaRequest(
-            'host', 'project', 'key', 'secret', test_date=12345)
+            'protocol', 'host', 'project', 'key', 'secret', test_date=12345)
 
         self.assertEqual(req.test_date, 12345)
 
 
     def test_add_datazilla_result(self):
         """Can add a DatazillaResult to a DatazillaRequest."""
-        req = DatazillaRequest('host', 'project', 'key', 'secret')
+        req = DatazillaRequest(
+            'protocol', 'host', 'project', 'key', 'secret'
+            )
         res = DatazillaResult({'suite': {'test': [1, 2, 3]}})
 
         req.add_datazilla_result(res)
@@ -24,7 +26,9 @@ class DatazillaRequestTest(unittest.TestCase):
 
     def test_add_second_datazilla_result(self):
         """Adding a second DatazillaResult joins their results."""
-        req = DatazillaRequest('host', 'project', 'key', 'secret')
+        req = DatazillaRequest(
+            'protocol', 'host', 'project', 'key', 'secret'
+            )
         res1 = DatazillaResult({'suite1': {'test': [1]}})
         res2 = DatazillaResult({'suite2': {'test': [2]}})
 
@@ -40,7 +44,9 @@ class DatazillaRequestTest(unittest.TestCase):
         collection = DatazillaResultsCollection(machine_name='localhost',
                                                 os='linux')
         test_date = collection.test_date
-        req = DatazillaRequest.create('host', 'project', 'key', 'secret', collection)
+        req = DatazillaRequest.create(
+            'protocol', 'host', 'project', 'key', 'secret', collection
+            )
         self.assertEqual(req.machine_name, 'localhost')
         self.assertEqual(req.os, 'linux')
         self.assertEqual(req.test_date, test_date)
@@ -53,6 +59,7 @@ class DatazillaRequestTest(unittest.TestCase):
         """Tests dataset creation for submission to datazilla"""
 
         req = DatazillaRequest(
+            protocol='http',
             host='host',
             project='project',
             oauth_key='key',
@@ -97,6 +104,7 @@ class DatazillaRequestTest(unittest.TestCase):
     def test_submit(self, mock_send):
         """Submits blob of JSON data for each test suite."""
         req = DatazillaRequest(
+            protocol='http',
             host='host',
             project='project',
             oauth_key='key',
@@ -169,11 +177,12 @@ class DatazillaRequestTest(unittest.TestCase):
         mock_time.return_value = 1342229050
         mock_generate_nonce.return_value = "46810593"
 
+        protocol = 'http'
         host = "datazilla.mozilla.org"
         project = "project"
         key = "oauth-key"
         secret = "oauth-secret"
-        req = DatazillaRequest(host, project, key, secret)
+        req = DatazillaRequest(protocol, host, project, key, secret)
 
         mock_conn = mock_HTTPConnection.return_value
         mock_request = mock_conn.request


### PR DESCRIPTION
The production version of datazilla uses SSL/HTTPS.  The httplib module used to send a request in datazilla_client has two separate connection functions to handle HTTP and HTTPS.  To account for this I added a "protocol" option to DatazillaRequest that allows the caller to specify "http" or "https" for the host. 
